### PR TITLE
Add retry decorator and fix issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,20 @@ platzi logout
 Para descargar un curso de Platzi, usa el comando download seguido de la URL del curso que deseas descargar. La URL puede encontrarse en la barra de direcciones al visualizar la página del curso en Platzi.
 
 ```console
-platzi download <url-del-curso>
+platzi download URL [OPTIONS]
+
+OPTIONS:
+  --overwrite / -w  Overwrite files if exist.
 ```
 
-Ejemplo:
+Ejemplos:
 
 ```console
-platzi download https://platzi.com/cursos/fastapi-2023/
+platzi download https://platzi.com/cursos/fastapi-2023
+```
+
+```console
+platzi download https://platzi.com/cursos/fastapi-2023 -w
 ```
 
 ### Borrar Caché

--- a/src/platzi/cli.py
+++ b/src/platzi/cli.py
@@ -40,6 +40,15 @@ def download(
             show_default=False,
         ),
     ],
+    overwrite: Annotated[
+        bool,
+        typer.Option(
+            "--overwrite",
+            "-w",
+            help="Overwrite files if exist.",
+            show_default=True,
+        ),
+    ] = False,
 ):
     """
     Download a Platzi course from the given URL.
@@ -53,7 +62,7 @@ def download(
     Example:
         platzi download https://platzi.com/cursos/fastapi-2023/
     """
-    asyncio.run(_download(url))
+    asyncio.run(_download(url, overwrite=overwrite))
 
 
 @app.command()
@@ -78,6 +87,6 @@ async def _logout():
         await platzi.logout()
 
 
-async def _download(url: str):
+async def _download(url: str, **kwargs):
     async with AsyncPlatzi() as platzi:
-        await platzi.download(url)
+        await platzi.download(url, **kwargs)

--- a/src/platzi/helpers.py
+++ b/src/platzi/helpers.py
@@ -1,5 +1,8 @@
+import asyncio
 import hashlib
 import json
+import time
+from functools import wraps
 
 
 def read_json(path: str) -> dict:
@@ -20,3 +23,34 @@ def write_file(path: str, content: str) -> None:
 def hash_id(input_string: str) -> str:
     hash_object = hashlib.sha256(input_string.encode("utf-8"))
     return hash_object.hexdigest()
+
+
+def retry(attempts: int = 5, delay: float = 1, backoff: bool = True):
+    def decorator(func):
+        is_async = asyncio.iscoroutinefunction(func)
+
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            for i in range(1, attempts + 1):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    if i == attempts:
+                        raise e
+                    wait = delay * (2 * i) if backoff else delay
+                    time.sleep(wait)
+
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            for i in range(1, attempts + 1):
+                try:
+                    return await func(*args, **kwargs)
+                except Exception as e:
+                    if i == attempts:
+                        raise e
+                    wait = delay * (2 * i) if backoff else delay
+                    await asyncio.sleep(wait)
+
+        return async_wrapper if is_async else sync_wrapper
+
+    return decorator

--- a/src/platzi/m3u8.py
+++ b/src/platzi/m3u8.py
@@ -11,15 +11,12 @@ import aiofiles
 import rnet
 from tqdm.asyncio import tqdm
 
-from .logger import Logger
-
 
 def ffmpeg_required(func):
     @functools.wraps(func)
     async def wrapper(*args, **kwargs):
         if not shutil.which("ffmpeg"):
-            Logger.error("ffmpeg is not installed")
-            return
+            raise Exception("ffmpeg is not installed")
         return await func(*args, **kwargs)
 
     return wrapper
@@ -160,6 +157,7 @@ async def _m3u8_dl(
         raise Exception("Error converting m3u8 to mp4")
 
 
+@ffmpeg_required
 async def m3u8_dl(
     url: str,
     path: str | Path,

--- a/src/platzi/m3u8.py
+++ b/src/platzi/m3u8.py
@@ -27,6 +27,22 @@ def _hash_id(input: str) -> str:
     return hash_object.hexdigest()
 
 
+def _extract_streaming_urls(content: str) -> list[str] | None:
+    BASE_URL = "https://mediastream.platzi.com"
+    pattern = r"(https?://[^\s]+|(?::)?///?[^\s]+)"
+    matches = re.findall(pattern, content)
+
+    urls = []
+    for match in matches:
+        if match.startswith("http"):
+            urls.append(match)
+        else:
+            full_url = BASE_URL.rstrip("/") + "/" + match.lstrip(":/")
+            urls.append(full_url)
+
+    return urls or None
+
+
 async def _ts_dl(url: str, path: Path, **kwargs):
     overwrite = kwargs.get("overwrite", False)
 
@@ -102,8 +118,7 @@ async def _m3u8_dl(
         if not response.ok:
             raise Exception("Error downloading m3u8")
 
-        pattern = r"https?://[^\s]+"
-        ts_urls = re.findall(pattern, await response.text())
+        ts_urls = _extract_streaming_urls(await response.text())
 
         if not ts_urls:
             raise Exception("No ts urls found")
@@ -187,8 +202,7 @@ async def m3u8_dl(
         if not response.ok:
             raise Exception("Error downloading m3u8")
 
-        pattern = r"https?://[^\s]+"
-        m3u8_urls = re.findall(pattern, await response.text())
+        m3u8_urls = _extract_streaming_urls(await response.text())
 
         if not m3u8_urls:
             raise Exception("No m3u8 urls found")

--- a/src/platzi/m3u8.py
+++ b/src/platzi/m3u8.py
@@ -28,9 +28,9 @@ def _hash_id(input: str) -> str:
 
 
 async def _ts_dl(url: str, path: Path, **kwargs):
-    overrides = kwargs.get("overrides", False)
+    overwrite = kwargs.get("overwrite", False)
 
-    if not overrides and path.exists():
+    if not overwrite and path.exists():
         return
 
     path.unlink(missing_ok=True)

--- a/src/platzi/m3u8.py
+++ b/src/platzi/m3u8.py
@@ -11,6 +11,8 @@ import aiofiles
 import rnet
 from tqdm.asyncio import tqdm
 
+from .helpers import retry
+
 
 def ffmpeg_required(func):
     @functools.wraps(func)
@@ -92,6 +94,7 @@ async def _worker_ts_dl(urls: list, dir: Path, **kwargs):
             bar.update(len(urls_batch))
 
 
+@retry()
 async def _m3u8_dl(
     url: str,
     path: str | Path,

--- a/src/platzi/utils.py
+++ b/src/platzi/utils.py
@@ -7,6 +7,8 @@ import rnet
 from playwright.async_api import Page
 from unidecode import unidecode
 
+from .helpers import retry
+
 
 async def progressive_scroll(
     page: Page, time: float = 3, delay: float = 0.1, steps: int = 250
@@ -89,6 +91,7 @@ def get_subtitles_url(content: str) -> str | None:
     return matches[0]
 
 
+@retry()
 async def download(url: str, path: Path, **kwargs):
     overwrite = kwargs.get("overwrite", False)
 

--- a/src/platzi/utils.py
+++ b/src/platzi/utils.py
@@ -90,7 +90,7 @@ def get_subtitles_url(content: str) -> str | None:
 
 
 async def download(url: str, path: Path, **kwargs):
-    overwrite = kwargs.get("overrides", False)
+    overwrite = kwargs.get("overwrite", False)
 
     if not overwrite and path.exists():
         return

--- a/src/platzi/utils.py
+++ b/src/platzi/utils.py
@@ -90,9 +90,9 @@ def get_subtitles_url(content: str) -> str | None:
 
 
 async def download(url: str, path: Path, **kwargs):
-    overrides = kwargs.get("overrides", False)
+    overwrite = kwargs.get("overrides", False)
 
-    if not overrides and path.exists():
+    if not overwrite and path.exists():
         return
 
     path.unlink(missing_ok=True)
@@ -105,7 +105,7 @@ async def download(url: str, path: Path, **kwargs):
         if not response.ok:
             raise Exception("[Bad Response]")
 
-        async with aiofiles.open(path.as_posix(), "wb") as file:
+        async with aiofiles.open(path, "wb") as file:
             async with response.stream() as streamer:
                 async for chunk in streamer:
                     await file.write(chunk)


### PR DESCRIPTION
fix: rename `overrides` to `overwrite` in `_ts_dl` and `download` functions  
fix: extract streaming URLs in `m3u8_dl`  
fix: add `ffmpeg` availability check in decorator  
feat: add `retry` decorator  
feat: add `overwrite` option to download function
