### PR TITLE
fix(rnet-client): send headers correctly in GET request

### DIFF
--- a/src/platzi/m3u8.py
+++ b/src/platzi/m3u8.py
@@ -11,6 +11,7 @@ import aiofiles
 import rnet
 from tqdm.asyncio import tqdm
 
+from .constants import REFERER
 from .helpers import retry
 
 
@@ -55,7 +56,7 @@ async def _ts_dl(url: str, path: Path, **kwargs):
     path.parent.mkdir(parents=True, exist_ok=True)
 
     client = rnet.Client(impersonate=rnet.Impersonate.Firefox139)
-    response: rnet.Response = await client.get(url, **kwargs)
+    response: rnet.Response = await client.get(url, headers={"Referer": REFERER})
 
     try:
         if not response.ok:
@@ -122,7 +123,7 @@ async def _m3u8_dl(
     tmp_dir.mkdir(parents=True, exist_ok=True)
 
     client = rnet.Client(impersonate=rnet.Impersonate.Firefox139)
-    response: rnet.Response = await client.get(url, **kwargs)
+    response: rnet.Response = await client.get(url, headers={"Referer": REFERER})
 
     try:
         if not response.ok:
@@ -210,7 +211,7 @@ async def m3u8_dl(
         return
 
     client = rnet.Client(impersonate=rnet.Impersonate.Firefox139)
-    response: rnet.Response = await client.get(url, **kwargs)
+    response: rnet.Response = await client.get(url, headers={"Referer": REFERER})
 
     try:
         if not response.ok:


### PR DESCRIPTION
Ensure headers are properly passed instead of using kwargs